### PR TITLE
feat: overtime calculation

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -325,8 +325,8 @@
 
         const rows = absencePage.querySelectorAll('#userTypesAbsences .ListAbsenceTBody .entete_config');
         const overtimeRows = Array.from(rows)
-          .filter((r) => /^récupération\shoraire\s[0-9]{4}$/i.test(r.innerText.trim()));
-        const overtimeBalances = overtimeRows.map((row) => row.parentNode.querySelector('#solde').innerText.trim());
+          .filter((r) => /^récupération\shoraire\s[0-9]{4}$/i.test(r.textContent.trim()));
+        const overtimeBalances = overtimeRows.map((row) => row.parentNode.querySelector('#solde').textContent.trim());
 
         return overtimeBalances
           .map((balance) => stringToMinutes(balance))
@@ -352,18 +352,24 @@
 
         Array.from(rows).forEach((tr) => {
           Array.from(tr.childNodes).forEach((td) => {
-            if (td.innerText && /^différentiel\shebdomadaire|compensation\stemps$/i.test(td.innerText.trim())) {
-              if (td.nextElementSibling && td.nextElementSibling.innerText) {
-                differences.push(stringToMinutes(td.nextElementSibling.innerText));
+            if (td.textContent && /^différentiel\shebdomadaire|compensation\stemps$/i.test(td.textContent.trim())) {
+              if (td.nextElementSibling && td.nextElementSibling.textContent) {
+                differences.push(stringToMinutes(td.nextElementSibling.textContent));
               }
             }
           })
         });
 
-        const prevDay = sheetPage.querySelector('.trToday').previousElementSibling;
-        const prevDayDiffrence = Array.from(prevDay.querySelectorAll('td')).pop();
-        if (prevDayDiffrence && prevDayDiffrence.innerText) {
-          differences.unshift(stringToMinutes(prevDayDiffrence.innerText.trim()));
+        let weekDifference = 0;
+        let row = sheetPage.querySelector('.trToday');
+        do {
+          row = row.nextElementSibling;
+        } while (!row.classList.contains('summaryTr'));
+
+        if (row) {
+          const difference = row.querySelector('td:last-child').textContent.trim();
+          weekDifference = stringToMinutes(difference);
+          differences.unshift(weekDifference);
         }
 
         return differences

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -155,30 +155,28 @@
       try {
         overtimeBalance = await getOvertimeBalance();
       } catch (e) {
-        console.error('Failed to download overtime balances');
+        console.error('Failed to download overtime balance');
         console.error(e);
       }
 
-      if (overtimeBalance !== 0) {
-        let weeklyDifference = 0;
-        try {
-          weeklyDifference = await getWeeklyDifference();
-        } catch (e) {
-          console.error('Failed to download weekly differences');
-          console.error(e);
-        }
-
-        const overTimeButton = document.createElement('button');
-        overTimeButton.classList.add('btn', 'ams-btn');
-        overTimeButton.setAttribute('title', 'Heure(s) supplémentaire(s)');
-        overTimeButton.innerHTML = `
-          <i class="fa fa-${(overtimeBalance + weeklyDifference) > 0 ? 'plus' : 'minus'}"></i>
-          <span class="text"></span>
-        `;
-
-        overTimeButton.querySelector('.text').textContent = minutesToString(overtimeBalance + weeklyDifference);
-        summary.appendChild(overTimeButton);
+      let weeklyDifference = 0;
+      try {
+        weeklyDifference = await getWeeklyDifference();
+      } catch (e) {
+        console.error('Failed to download weekly difference');
+        console.error(e);
       }
+
+      const overTimeButton = document.createElement('button');
+      overTimeButton.classList.add('btn', 'ams-btn');
+      overTimeButton.setAttribute('title', 'Heure(s) supplémentaire(s)');
+      overTimeButton.innerHTML = `
+        <i class="fa fa-${(overtimeBalance + weeklyDifference) > 0 ? 'plus' : 'minus'}"></i>
+        <span class="text"></span>
+      `;
+
+      overTimeButton.querySelector('.text').textContent = minutesToString(overtimeBalance + weeklyDifference);
+      summary.appendChild(overTimeButton);
     }
 
     function createSpinnerButton() {
@@ -367,8 +365,11 @@
         } while (!row.classList.contains('summaryTr'));
 
         if (row) {
+          const todayDifference = sheetPage.querySelector('.trToday td:last-child').textContent.trim();
+          const todayDiff = stringToMinutes(todayDifference);
+      
           const difference = row.querySelector('td:last-child').textContent.trim();
-          weekDifference = stringToMinutes(difference);
+          weekDifference = stringToMinutes(difference) + Math.abs(todayDiff);
           differences.unshift(weekDifference);
         }
 


### PR DESCRIPTION
- Retrieving the balance(s) on the "Absences" page
- Conversion of balances (ex: 5h 42m) in minutes
- Additions of balances (ex: A + B + -C)
- Recovering balances from weekly differentials
- Conversion of weekly balances (ex: 1h07) in minutes
- Adding weekly balances (ex: A + B + -C) and the previous day's differential
- Display of the overtime button in the line of the day. (with a "+" if positive and a "-" if negative)

![image](https://user-images.githubusercontent.com/38247370/174819679-217b5930-dbff-4a9b-9943-9cf6dba81469.png)
